### PR TITLE
Callback function when packet arrives

### DIFF
--- a/inc/IPbusRequest.h
+++ b/inc/IPbusRequest.h
@@ -9,7 +9,7 @@ namespace ipbus
 {
     class IPbusRequest: public IPbusPacket
     {
-        public:
+       public:
 
         IPbusRequest();
         void reset(int packetID = 0);
@@ -18,10 +18,15 @@ namespace ipbus
         uint16_t getExpectedResponseSize() const { return m_expectedResponseSize; }
         uint32_t* getDataOut(int idx) { return m_dataOut[idx]; }
 
-        private:
+        bool isPartialSwt() const;
+
+        void markPartialSwt();
+
+       private:
 
         uint16_t m_expectedResponseSize;
         std::vector<uint32_t*> m_dataOut;
+        bool m_isPartialSwt = false;
     };
 }
 

--- a/inc/IPbusSlave.h
+++ b/inc/IPbusSlave.h
@@ -2,6 +2,7 @@
 #include"IPbusResponse.h"
 #include"Memory.h"
 #include<boost/asio.hpp>
+#include <functional>
 
 #ifndef IPBUS_SLAVE
 #define IPBUS_SLAVE
@@ -10,7 +11,7 @@ namespace ipbus
 {
     class IPbusSlave
     {
-        public:
+       public:
         IPbusSlave(boost::asio::io_context& io, Memory& memory, uint16_t lport);
         bool openSocket();
         void startAsyncRecv();
@@ -19,8 +20,9 @@ namespace ipbus
         const IPbusResponse& getResponse() { return m_response; }
 
         static constexpr uint8_t BufferSize = UINT8_MAX;
-        
-        private:
+    
+        void setRequestCallback(std::function<void(const IPbusRequest& req)> f);
+       private:
 
         void handleRequest(const boost::system::error_code& ec, std::size_t length);
         void sendResponse(const boost::asio::ip::udp::endpoint&);
@@ -51,6 +53,8 @@ namespace ipbus
         uint32_t m_buffer[BufferSize];
 
         Memory& m_memory;
+
+        std::function<void(const IPbusRequest& req)> m_requestCallback;
     };
 }
 

--- a/src/IPbusMaster.cxx
+++ b/src/IPbusMaster.cxx
@@ -14,8 +14,8 @@ IPbusMaster::IPbusMaster(boost::asio::io_context& ioContext, std::string address
                                                                                                                     m_ipAddress(address),
                                                                                                                     m_localEndpoint(boost::asio::ip::udp::v4(), m_localPort),
                                                                                                                     m_remoteEndpoint(boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(m_ipAddress), m_remotePort)),
-                                                                                                                    m_timer(ioContext),
-                                                                                                                    m_socket(ioContext)
+                                                                                                                    m_socket(ioContext),
+                                                                                                                    m_timer(ioContext)
 
 {
   openSocket();

--- a/src/IPbusRequest.cxx
+++ b/src/IPbusRequest.cxx
@@ -16,6 +16,7 @@ namespace ipbus
         m_size = 1;
         m_transactionsNumber = 0;
         m_expectedResponseSize = 1;
+        m_isPartialSwt = false;
         m_dataOut.clear();
     }
 

--- a/src/IPbusRequest.cxx
+++ b/src/IPbusRequest.cxx
@@ -73,4 +73,12 @@ namespace ipbus
 
         m_dataOut.push_back(dataOut);
     }
+
+    bool IPbusRequest::isPartialSwt() const {
+        return m_isPartialSwt;
+    }
+
+    void IPbusRequest::markPartialSwt() {
+        m_isPartialSwt = true;
+    }
 }

--- a/src/IPbusSlave.cxx
+++ b/src/IPbusSlave.cxx
@@ -6,11 +6,11 @@ namespace ipbus
 {
     IPbusSlave::IPbusSlave(boost::asio::io_context& io, Memory& m_memory, uint16_t lport):
         m_ioContext(io),
-        m_memory(m_memory),
-        m_socket(io),
         m_localPort(lport),
+        m_socket(io),
         m_remoteEndpoint(boost::asio::ip::udp::v4(), 0),
-        m_localEndpoint(boost::asio::ip::udp::v4(), lport)
+        m_localEndpoint(boost::asio::ip::udp::v4(), lport),
+        m_memory(m_memory)
     {
         if(openSocket())
         {
@@ -49,6 +49,8 @@ namespace ipbus
 
         m_request.setSize(length/wordSize);
         m_response.reset();
+
+        m_requestCallback(m_request);
 
         uint16_t idx_request = 1;
         
@@ -210,5 +212,9 @@ namespace ipbus
         }
         return Response;
     }
+
+    void IPbusSlave::setRequestCallback(std::function<void(const IPbusRequest& req)> f) {
+        m_requestCallback = f;
+    } 
 } // namespace ipbus
 


### PR DESCRIPTION
Adds the option to have a callback functor, executed every time a packet arrives to the slave - necessary for mock's ability to track incoming packets